### PR TITLE
modify chart's yaml so that user can use default storage class

### DIFF
--- a/stolon/templates/keeper-statefulset.yaml
+++ b/stolon/templates/keeper-statefulset.yaml
@@ -106,11 +106,13 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size }}
-  {{- if .Values.persistence.storageClassName }}
-        storageClassName: {{ .Values.persistence.storageClassName | quote }}
+    {{- if .Values.persistentVolume.storageClassName }}
+    {{- if (eq "-" .Values.persistentVolume.storageClassName) }}
+        storageClassName: ""
     {{- else }}
-        storageClassName: default
-  {{- end }}
+        storageClassName: "{{ .Values.persistentVolume.storageClassName }}"
+    {{- end }}
+    {{- end }}
 {{- else }}
         - name: stolon-data
           emptyDir: {}

--- a/stolon/values.yaml
+++ b/stolon/values.yaml
@@ -146,7 +146,7 @@ persistence:
   accessMode: ReadWriteOnce
 
   ## Persistant Volume Storage Class Name
-  storageClassName: standard
+  # storageClassName: "-"
 
   ## Persistent Volume Storage Size.
   ##


### PR DESCRIPTION
Refer to [storageclass's usage specification](https://github.com/helm/charts/blob/master/stable/redis-ha/templates/redis-ha-statefulset.yaml), modify the chart so that user can use default storageclass.

[redis-ha-statefulset.yaml](https://github.com/helm/charts/blob/master/stable/redis-ha/templates/redis-ha-statefulset.yaml)

```yaml
    {{- if .Values.persistentVolume.storageClass }}
    {{- if (eq "-" .Values.persistentVolume.storageClass) }}
      storageClassName: ""
    {{- else }}
      storageClassName: "{{ .Values.persistentVolume.storageClass }}"
    {{- end }}
    {{- end }}
```

[values.yaml](https://github.com/helm/charts/blob/master/stable/redis-ha/values.yaml)

```yaml
  ## If defined, storageClassName: <storageClass>
  ## If set to "-", storageClassName: "", which disables dynamic provisioning
  ## If undefined (the default) or set to null, no storageClassName spec is
  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
  ##   GKE, AWS & OpenStack)
  ##
  # storageClass: "-"
```