### PR TITLE
Use custome UIDs for stolon keepers

### DIFF
--- a/stolon/Chart.yaml
+++ b/stolon/Chart.yaml
@@ -1,6 +1,6 @@
 name: stolon
 home: https://github.com/sorintlab/stolon
-version: 0.7.0
+version: 0.7.1
 description: Stolon Helm Chart for Kubernetes.
 sources:
   - https://github.com/sorintlab/stolon

--- a/stolon/README.md
+++ b/stolon/README.md
@@ -67,6 +67,7 @@ The following tables lists the configurable parameters of the helm chart and the
 | `proxy.affinity`                        | Affinity settings for proxy pod assignment     | `{}`                                                         |
 | `proxy.nodeSelector`                    | Node labels for proxy pod assignment           | `{}`                                                         |
 | `proxy.tolerations`                     | Toleration labels for proxy pod assignment     | `[]`                                                         |
+| `keeper.uid_prefix`                     | Keeper prefix name                             | `keeper`                                                     |
 | `keeper.replicas`                       | Number of keeper nodes                         | `2`                                                          |
 | `keeper.resources`                      | Keeper resource requests/limit                 | Memory: `256Mi`, CPU: `100m`                                 |
 | `keeper.affinity`                       | Affinity settings for keeper pod assignment    | `{}`                                                         |

--- a/stolon/templates/keeper-statefulset.yaml
+++ b/stolon/templates/keeper-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
           - |
             # Generate our keeper uid using the pod index
             IFS='-' read -ra ADDR <<< "$(hostname)"
-            export STKEEPER_UID="keeper${ADDR[-1]}"
+            export STKEEPER_UID="{{ .Values.keeper.uid_prefix }}${ADDR[-1]}"
             export POD_IP=$(hostname -i)
             export STKEEPER_PG_LISTEN_ADDRESS=$POD_IP
             export STOLON_DATA=/stolon-data

--- a/stolon/values.yaml
+++ b/stolon/values.yaml
@@ -103,6 +103,7 @@ proxy:
 
 keeper:
   replicas: 3
+  uid_prefix: "stolon"
   ## Set serviceType to nodePort if needed
   ## keeper service is used to route RO requests to all nodes
   # serviceType: NodePort


### PR DESCRIPTION
It help to create different UIDs for stolon keepers when you create two stolon clusters on one backend storage

in [helm/charts](https://github.com/helm/charts/pull/12136)